### PR TITLE
Feature/composite

### DIFF
--- a/.github/actions/service_mongo/action.yml
+++ b/.github/actions/service_mongo/action.yml
@@ -1,0 +1,14 @@
+name: "Service: Mongo"
+description: "Sets up a Mongo DB service for testing purposes."
+runs:
+  using: "composite"
+  steps:
+    - name: "Configure MongoDB Hostname"
+      run: |
+        sudo echo "127.0.0.1 mongo" | sudo tee -a /etc/hosts
+      shell: bash
+
+    - name: "Start MongoDB"
+      uses: supercharge/mongodb-github-action@1.7.0
+      with:
+        mongodb-version: '4.4'

--- a/.github/actions/service_mysql/action.yml
+++ b/.github/actions/service_mysql/action.yml
@@ -1,0 +1,13 @@
+name: "Service: MySQL"
+description: "Sets up a MySQL service for testing purposes."
+runs:
+  using: "composite"
+  steps:
+    - name: "Configure MySQL Hostname"
+      run: |
+        sudo echo "127.0.0.1 mysql" | sudo tee -a /etc/hosts
+      shell: bash
+
+    - name: "Start MySQL"
+      run: sudo systemctl start mysql
+      shell: bash

--- a/.github/actions/slack_notify/action.yml
+++ b/.github/actions/slack_notify/action.yml
@@ -1,0 +1,92 @@
+name: "Slack Notify"
+description: "Send a notification to Slack. Used to signal successful builds and deployments."
+inputs:
+  event:
+    description: "The 'event' for which we are notifying: ['build','deploy']"
+    required: true
+  webhook_url:
+    description: "The Slack webhook for your workspace."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: "Build Notification"
+      if: inputs.event == 'build'
+      uses: slackapi/slack-github-action@v1.19.0
+      with:
+        channel-id: 'G3184HDT6' # CICD
+        payload: |
+          {
+            "attachments": [
+              {
+                "color": "${{ success() && '#2eb886' || '#a30200' }}",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*${{github.event.repository.name}}*: Build <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> by ${{github.actor}} ${{ success() && 'successful' || 'failed' }}! ${{ success() && ':ok_hand:' || ':scream::cry:' }}"
+                    }
+                  },
+                  { "type": "divider" },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": ${{ toJSON(github.event.head_commit.message) }}
+                    },
+                    "accessory": {
+                      "type": "image",
+                      "image_url": "${{ success() && 'https://popcat.click/twitter-card.jpg' || 'https://www.meme-arsenal.com/memes/aaf82c28cdb84f5ab79dd8eb460c1d11.jpg' }}",
+                      "alt_text": "${{ success() && 'Nice!' || 'Oof.' }}"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": ":github: *Repository*: <${{ github.server_url }}/${{ github.repository}}|${{ github.repository }}>\n:git: *Ref*: ${{ github.ref_name}}\n:1234: *Build Number*: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>\n:docker: *Image Tag*: ${{needs.build.outputs.image_tag_build}}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+    - name: "Deployment Notification"
+      if: inputs.event == 'deploy'
+      uses: slackapi/slack-github-action@v1.19.0
+      with:
+        channel-id: 'G3184HDT6' # CICD
+        payload: |
+          {
+            "attachments": [
+              {
+                "color": "${{ success() && '#2eb886' || '#a30200' }}",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*${{ success() && 'Deployment Success' || 'Deployment Failure' }}: ${{github.event.repository.name}}*"
+                    }
+                  },
+                  { "type": "divider" },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{needs.build.outputs.image_tag_build}} to *${{github.ref_name}}* ${{ success() && 'successful' || 'failed' }}! ${{ success() && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/actions/slack_notify/action.yml
+++ b/.github/actions/slack_notify/action.yml
@@ -7,6 +7,9 @@ inputs:
   webhook_url:
     description: "The Slack webhook for your workspace."
     required: true
+  success:
+    description: "The status of the build pipeline. Expects a boolean as returned by inputs.success"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -19,13 +22,13 @@ runs:
           {
             "attachments": [
               {
-                "color": "${{ success() && '#2eb886' || '#a30200' }}",
+                "color": "${{ inputs.success && '#2eb886' || '#a30200' }}",
                 "blocks": [
                   {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "*${{github.event.repository.name}}*: Build <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> by ${{github.actor}} ${{ success() && 'successful' || 'failed' }}! ${{ success() && ':ok_hand:' || ':scream::cry:' }}"
+                      "text": "*${{github.event.repository.name}}*: Build <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> by ${{github.actor}} ${{ inputs.success && 'successful' || 'failed' }}! ${{ inputs.success && ':ok_hand:' || ':scream::cry:' }}"
                     }
                   },
                   { "type": "divider" },
@@ -37,8 +40,8 @@ runs:
                     },
                     "accessory": {
                       "type": "image",
-                      "image_url": "${{ success() && 'https://popcat.click/twitter-card.jpg' || 'https://www.meme-arsenal.com/memes/aaf82c28cdb84f5ab79dd8eb460c1d11.jpg' }}",
-                      "alt_text": "${{ success() && 'Nice!' || 'Oof.' }}"
+                      "image_url": "${{ inputs.success && 'https://popcat.click/twitter-card.jpg' || 'https://www.meme-arsenal.com/memes/aaf82c28cdb84f5ab79dd8eb460c1d11.jpg' }}",
+                      "alt_text": "${{ inputs.success && 'Nice!' || 'Oof.' }}"
                     }
                   },
                   {
@@ -65,13 +68,13 @@ runs:
           {
             "attachments": [
               {
-                "color": "${{ success() && '#2eb886' || '#a30200' }}",
+                "color": "${{ inputs.success && '#2eb886' || '#a30200' }}",
                 "blocks": [
                   {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "*${{ success() && 'Deployment Success' || 'Deployment Failure' }}: ${{github.event.repository.name}}*"
+                      "text": "*${{ inputs.success && 'Deployment Success' || 'Deployment Failure' }}: ${{github.event.repository.name}}*"
                     }
                   },
                   { "type": "divider" },
@@ -79,7 +82,7 @@ runs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{needs.build.outputs.image_tag_build}} to *${{github.ref_name}}* ${{ success() && 'successful' || 'failed' }}! ${{ success() && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
+                      "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{needs.build.outputs.image_tag_build}} to *${{github.ref_name}}* ${{ inputs.success && 'successful' || 'failed' }}! ${{ inputs.success && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
                     }
                   }
                 ]
@@ -87,6 +90,6 @@ runs:
             ]
           }
       env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 

--- a/.github/actions/slack_notify/action.yml
+++ b/.github/actions/slack_notify/action.yml
@@ -10,6 +10,9 @@ inputs:
   success:
     description: "The status of the build pipeline. Expects a boolean as returned by inputs.success"
     required: true
+  image_tag:
+    description: "An associated image tag with which to report back to "
+    required: true
 runs:
   using: "composite"
   steps:
@@ -48,7 +51,7 @@ runs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": ":github: *Repository*: <${{ github.server_url }}/${{ github.repository}}|${{ github.repository }}>\n:git: *Ref*: ${{ github.ref_name}}\n:1234: *Build Number*: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>\n:docker: *Image Tag*: ${{needs.build.outputs.image_tag_build}}"
+                      "text": ":github: *Repository*: <${{ github.server_url }}/${{ github.repository}}|${{ github.repository }}>\n:git: *Ref*: ${{ github.ref_name}}\n:1234: *Build Number*: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>\n:docker: *Image Tag*: ${{inputs.image_tag}}"
                     }
                   }
                 ]
@@ -82,7 +85,7 @@ runs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{needs.build.outputs.image_tag_build}} to *${{github.ref_name}}* ${{ inputs.success && 'successful' || 'failed' }}! ${{ inputs.success && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
+                      "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{inputs.image_tag}} to *${{github.ref_name}}* ${{ inputs.success && 'successful' || 'failed' }}! ${{ inputs.success && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
                     }
                   }
                 ]

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -184,6 +184,7 @@ jobs:
         uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
           event: build
+          success: success()
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 
@@ -242,4 +243,5 @@ jobs:
         uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
           event: deploy
+          success: success()
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -30,24 +30,18 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
+      - name: "Git SSH"
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: linc-technologies/.github/.github/actions/git_ssh@master
+        with:
+          key: ${{ secrets.VCS_SSH_KEY }}
+
       - name: "Setup Node 10.21"
         uses: actions/setup-node@v3
         with:
           node-version: 10.21
           cache: 'npm'
           cache-dependency-path: linced-*/package-lock.json
-
-      - name: "SSH Keyscan"
-        id: scan
-        run: echo "::set-output name=known_hosts::$(ssh-keyscan -t rsa github.com)"
-
-      - name: "SSH Key Install"
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.VCS_SSH_KEY }}
-          name: id_rsa
-          known_hosts: ${{ steps.scan.outputs.known_hosts }}
-          if_key_exists: replace
 
       - name: "Login to ACR"
         uses: docker/login-action@v2

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -13,8 +13,6 @@ on:
         type: string
         required: true
 
-
-
 env:
   CONTAINER_REGISTRY: linced.azurecr.io/linc-ed
 
@@ -229,7 +227,7 @@ jobs:
         run: kubectl version
 
       # Deploy specific container revision based on workflow inputs
-      - name: Kubernetes Deploy
+      - name: "Kubernetes Deploy"
         env:
           CONTAINER: ${{ inputs.CONTAINER }}
           DEPLOYMENT: ${{ inputs.DEPLOYMENT }}

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -181,59 +181,13 @@ jobs:
             ${{ steps.tag.outputs.image_tag_branch }}
           file: Dockerfile.drone
 
-  notify_build:
-    name: "Notify Build"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [ build ]
-    continue-on-error: true
-    steps:
-      # https://stackoverflow.com/questions/72221266/sanitize-github-context-in-github-actions
-      - name: "Build Notification"
-        id: slack
-        uses: slackapi/slack-github-action@v1.19.0
+      - name: "Slack Notify"
+        if: success() || failure()
+        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
-          channel-id: 'G3184HDT6' # CICD
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.build.result == 'success' && '#2eb886' || '#a30200' }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*${{github.event.repository.name}}*: Build <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> by ${{github.actor}} ${{ needs.build.result == 'success' && 'successful' || 'failed' }}! ${{ needs.build.result == 'success' && ':ok_hand:' || ':scream::cry:' }}"
-                      }
-                    },
-                    { "type": "divider" },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ${{ toJSON(github.event.head_commit.message) }}
-                      },
-                      "accessory": {
-                        "type": "image",
-                        "image_url": "${{ needs.build.result == 'success' && 'https://popcat.click/twitter-card.jpg' || 'https://www.meme-arsenal.com/memes/aaf82c28cdb84f5ab79dd8eb460c1d11.jpg' }}",
-                        "alt_text": "${{ needs.build.result == 'success' && 'Nice!' || 'Oof.' }}"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ":github: *Repository*: <${{ github.server_url }}/${{ github.repository}}|${{ github.repository }}>\n:git: *Ref*: ${{ github.ref_name}}\n:1234: *Build Number*: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>\n:docker: *Image Tag*: ${{needs.build.outputs.image_tag_build}}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          event: build
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 
   deploy:
     name: "Deploy"
@@ -285,42 +239,9 @@ jobs:
           echo "Updating $CONTAINER in $DEPLOYMENT to $IMAGE in the $NAMESPACE namespace."
           kubectl set image deployment/$DEPLOYMENT  $CONTAINER=$IMAGE --record=true --namespace=${NAMESPACE}
 
-  notify_deploy:
-    name: "Notify Deploy"
-    runs-on: ubuntu-latest
-    if: always() && needs.deploy.result != 'skipped'
-    needs: [ deploy ]
-    steps:
-      - name: "Deployment Notification"
-        id: slack
-        uses: slackapi/slack-github-action@v1.19.0
+      - name: "Slack Notify"
+        if: success() || failure()
+        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
-          channel-id: 'G3184HDT6' # CICD
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.deploy.result == 'success' && '#2eb886' || '#a30200' }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*${{ needs.deploy.result == 'success' && 'Deployment Success' || 'Deployment Failure' }}: ${{github.event.repository.name}}*"
-                      }
-                    },
-                    { "type": "divider" },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{needs.build.outputs.image_tag_build}} to *${{github.ref_name}}* ${{ needs.deploy.result == 'success' && 'successful' || 'failed' }}! ${{ needs.deploy.result == 'success' && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          event: deploy
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: "Slack Notify"
         if: success() || failure()
-        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
+        uses: linc-technologies/.github/.github/actions/slack_notify@master
         with:
           event: build
           success: success()
@@ -240,7 +240,7 @@ jobs:
 
       - name: "Slack Notify"
         if: success() || failure()
-        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
+        uses: linc-technologies/.github/.github/actions/slack_notify@master
         with:
           event: deploy
           success: success()

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,6 +103,7 @@ jobs:
         uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
           event: build
+          success: success()
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy:
@@ -161,4 +162,6 @@ jobs:
         uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
           event: deploy
+          success: success()
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: "Setup MySQL"
         if: github.event.repository.name == 'finance'
-        uses: linc-technologies/.github/.github/actions/service_finance@feature/composite
+        uses: linc-technologies/.github/.github/actions/service_mysql@feature/composite
 
 
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,15 +25,13 @@ jobs:
         with:
           pat: ${{ secrets.CICD_TOKEN }}
 
-      # Setup Go
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: '1.17' # The Go version to download (if necessary) and use.
 #          cache: true $ TODO: Throwing issues with repeat builds....
 
-      # Run build of the application
-      - name: Run build
+      - name: "Build"
         env:
           GOPRIVATE: github.com/linc-technologies
           CGO_ENABLED: 0
@@ -49,17 +47,14 @@ jobs:
         if: github.event.repository.name == 'finance'
         uses: linc-technologies/.github/.github/actions/service_mysql@feature/composite
 
-
-
-      # Run testing on the code
-      - name: Run testing
+      - name: "Test"
         run: go test -vet=off -tags internal -v ./...
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
       # TODO: Create a new workflow for dependabot with only composite actions to limit steps like these
-      - name: Login to ACR
+      - name: "Login to ACR"
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: docker/login-action@v2
         with:
@@ -113,8 +108,7 @@ jobs:
     needs: [build]
     steps:
 
-      # Install Kubectl
-      - name: Configure Kubectl
+      - name: "Configure Kubectl"
         uses: azure/setup-kubectl@v2.0
         with:
           version: 'v1.22.6'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,24 +7,18 @@ on:
 env:
   CONTAINER_REGISTRY: linced.azurecr.io/linc-ed
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # The "build" workflow
   build:
     name: "Build"
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
     outputs:
       build_num: ${{ steps.tag.outputs.build_num }}
       image_tag_build: ${{ steps.tag.outputs.image_tag_build }}
       image_tag_branch: ${{ steps.tag.outputs.image_tag_branch }}
-
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+
+      - name: "Checkout"
+        uses: actions/checkout@v2
 
       - name: "Git HTTPS"
         uses: linc-technologies/.github/.github/actions/git_http@master
@@ -125,7 +119,7 @@ jobs:
           version: 'v1.22.6'
 
       # If we're deploying from a non-production branch, configure Kubectl with Dev cluster secrets
-      - name: Kubernetes Auth (Dev AU East)
+      - name: "Kubernetes Auth (Dev AU East)"
         if: ${{ github.ref  != 'refs/heads/production' }}
         run: |
           kubectl config set-credentials default --token=${{ secrets.DEVELOPMENT_AU_EAST_AKS_TOKEN }}
@@ -137,7 +131,7 @@ jobs:
           kubectl config use-context default
 
       # If we're deploying from a production branch, configure Kubectl with Prod cluster secrets
-      - name: Kubernetes Auth (Prod AU East)
+      - name: "Kubernetes Auth (Prod AU East)"
         if: ${{ github.ref == 'refs/heads/production' }}
         run: |
           kubectl config set-credentials default --token=${{ secrets.PRODUCTION_AU_EAST_AKS_TOKEN }}
@@ -152,7 +146,7 @@ jobs:
       - run: kubectl version
 
       # Deploy specific container revision
-      - name: Kubernetes Deploy
+      - name: "Kubernetes Deploy"
         env:
           CONTAINER: ${{ github.event.repository.name }}
           DEPLOYMENT: ${{ github.event.repository.name }}-deployment

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,30 +47,15 @@ jobs:
           cd ./cmd/${{ github.event.repository.name }}/
           go build -tags internal -ldflags="-s -w" -v
 
-# TODO: Change this to CD to a valid directory, ensure it will not cause widespread breaks
-#      # Run vet & lint on the code
-#      - name: Run vet & lint
-#        run: |
-#          go vet .
-#          golint .
-
-      # Test code expects to access services @ `mongo` / `mysql` per previous build system
-      - name: Service Hostnames
-        run: |
-          sudo echo "127.0.0.1 mongo" | sudo tee -a /etc/hosts
-          sudo echo "127.0.0.1 mysql" | sudo tee -a /etc/hosts
-
-      # Start a Mongo DB server for testing
-      - name: Start MongoDB
+      - name: "Setup Mongo"
         if: github.event.repository.name != 'finance'
-        uses: supercharge/mongodb-github-action@1.7.0
-        with:
-          mongodb-version: '4.4'
+        uses: linc-technologies/.github/.github/actions/service_mongo@feature/composite
 
-      # Start a MySQL server for testing, pre-installed on Ubuntu runners
-      - name: Start MySQL
+      - name: "Setup MySQL"
         if: github.event.repository.name == 'finance'
-        run: sudo systemctl start mysql
+        uses: linc-technologies/.github/.github/actions/service_finance@feature/composite
+
+
 
       # Run testing on the code
       - name: Run testing

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,11 +41,11 @@ jobs:
 
       - name: "Setup Mongo"
         if: github.event.repository.name != 'finance'
-        uses: linc-technologies/.github/.github/actions/service_mongo@feature/composite
+        uses: linc-technologies/.github/.github/actions/service_mongo@master
 
       - name: "Setup MySQL"
         if: github.event.repository.name == 'finance'
-        uses: linc-technologies/.github/.github/actions/service_mysql@feature/composite
+        uses: linc-technologies/.github/.github/actions/service_mysql@master
 
       - name: "Test"
         run: go test -vet=off -tags internal -v ./...
@@ -95,7 +95,7 @@ jobs:
 
       - name: "Slack Notify"
         if: success() || failure()
-        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
+        uses: linc-technologies/.github/.github/actions/slack_notify@master
         with:
           event: build
           success: success()
@@ -153,7 +153,7 @@ jobs:
 
       - name: "Slack Notify"
         if: success() || failure()
-        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
+        uses: linc-technologies/.github/.github/actions/slack_notify@master
         with:
           event: deploy
           success: success()

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,16 +27,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: "Git HTTPS"
-        if: ${{ github.actor == 'dependabot[bot]' }}
         uses: linc-technologies/.github/.github/actions/git_http@master
         with:
           pat: ${{ secrets.CICD_TOKEN }}
-
-      - name: "Git SSH"
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: linc-technologies/.github/.github/actions/git_ssh@master
-        with:
-          key: ${{ secrets.VCS_SSH_KEY }}
 
       # Setup Go
       - name: Setup Go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -119,58 +119,12 @@ jobs:
             ${{ steps.tag.outputs.image_tag_branch }}
           file: Dockerfile.drone
 
-  notify_build:
-    name: "Notify Build"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [ build ]
-    steps:
-      # https://stackoverflow.com/questions/72221266/sanitize-github-context-in-github-actions
-      - name: "Build Notification"
-        id: slack
-        uses: slackapi/slack-github-action@v1.19.0
+      - name: "Slack Notify"
+        if: success() || failure()
+        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
-          channel-id: 'G3184HDT6' # CICD
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.build.result == 'success' && '#2eb886' || '#a30200' }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*${{github.event.repository.name}}*: Build <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> by ${{github.actor}} ${{ needs.build.result == 'success' && 'successful' || 'failed' }}! ${{ needs.build.result == 'success' && ':ok_hand:' || ':scream::cry:' }}"
-                      }
-                    },
-                    { "type": "divider" },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ${{ toJSON(github.event.head_commit.message) }}
-                      },
-                      "accessory": {
-                        "type": "image",
-                        "image_url": "${{ needs.build.result == 'success' && 'https://popcat.click/twitter-card.jpg' || 'https://www.meme-arsenal.com/memes/aaf82c28cdb84f5ab79dd8eb460c1d11.jpg' }}",
-                        "alt_text": "${{ needs.build.result == 'success' && 'Nice!' || 'Oof.' }}"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ":github: *Repository*: <${{ github.server_url }}/${{ github.repository}}|${{ github.repository }}>\n:git: *Ref*: ${{ github.ref_name}}\n:1234: *Build Number*: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>\n:docker: *Image Tag*: ${{needs.build.outputs.image_tag_build}}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          event: build
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy:
     name: "Deploy"
@@ -223,43 +177,9 @@ jobs:
           echo "Updating $CONTAINER in $DEPLOYMENT to $IMAGE in the $NAMESPACE namespace."
           kubectl set image deployment/$DEPLOYMENT  $CONTAINER=$IMAGE --record=true --namespace=${NAMESPACE}
 
-
-  notify_deploy:
-    name: "Notify Deploy"
-    runs-on: ubuntu-latest
-    if: always() && needs.deploy.result != 'skipped'
-    needs: [ deploy ]
-    steps:
-      - name: "Deployment Notification"
-        id: slack
-        uses: slackapi/slack-github-action@v1.19.0
+      - name: "Slack Notify"
+        if: success() || failure()
+        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
-          channel-id: 'G3184HDT6' # CICD
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.deploy.result == 'success' && '#2eb886' || '#a30200' }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*${{ needs.deploy.result == 'success' && 'Deployment Success' || 'Deployment Failure' }}: ${{github.event.repository.name}}*"
-                      }
-                    },
-                    { "type": "divider" },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{needs.build.outputs.image_tag_build}} to *${{github.ref_name}}* ${{ needs.deploy.result == 'success' && 'successful' || 'failed' }}! ${{ needs.deploy.result == 'success' && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          event: deploy
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -4,21 +4,16 @@ on:
   workflow_dispatch:
   workflow_call:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # The "build" workflow
   build:
     name: "Build"
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
 
-      # Setup Go
-      - name: Setup Go
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Setup Go"
         uses: actions/setup-go@v3
         with:
           go-version: '1.17' # The Go version to download (if necessary) and use.
@@ -33,14 +28,7 @@ jobs:
         if: github.event.repository.name != 'finance'
         uses: linc-technologies/.github/.github/actions/service_mongo@feature/composite
 
-      # Start a Mongo DB server for testing
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.7.0
-        with:
-          mongodb-version: '4.4'
-
-      # Run testing on the code
-      - name: Run testing
+      - name: "Go Test"
         run: go test -vet=off -tags internal -v ./...
 
       - name: "Slack Notify"

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -26,14 +26,14 @@ jobs:
 
       - name: "Setup Mongo"
         if: github.event.repository.name != 'finance'
-        uses: linc-technologies/.github/.github/actions/service_mongo@feature/composite
+        uses: linc-technologies/.github/.github/actions/service_mongo@master
 
       - name: "Go Test"
         run: go test -vet=off -tags internal -v ./...
 
       - name: "Slack Notify"
         if: success() || failure()
-        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
+        uses: linc-technologies/.github/.github/actions/slack_notify@master
         with:
           event: build
           success: success()

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -29,18 +29,9 @@ jobs:
         with:
           pat: ${{ secrets.CICD_TOKEN }}
 
-# TODO: Change this to CD to a valid directory, ensure it will not cause widespread breaks
-#      # Run vet & lint on the code
-#      - name: Run vet & lint
-#        run: |
-#          go vet .
-#          golint .
-
-      # Test code expects to access services @ `mongo` / `mysql` per previous build system
-      - name: Service Hostnames
-        run: |
-          sudo echo "127.0.0.1 mongo" | sudo tee -a /etc/hosts
-          sudo echo "127.0.0.1 mysql" | sudo tee -a /etc/hosts
+      - name: "Setup Mongo"
+        if: github.event.repository.name != 'finance'
+        uses: linc-technologies/.github/.github/actions/service_mongo@feature/composite
 
       # Start a Mongo DB server for testing
       - name: Start MongoDB

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -24,22 +24,10 @@ jobs:
           go-version: '1.17' # The Go version to download (if necessary) and use.
           cache: true
 
-      - name: "SSH Keyscan"
-        id: scan
-        run: echo "::set-output name=known_hosts::$(ssh-keyscan -t rsa github.com)"
-
-      - name: "SSH Key Install"
-        uses: shimataro/ssh-key-action@v2
+      - name: "Git HTTPS"
+        uses: linc-technologies/.github/.github/actions/git_http@master
         with:
-          key: ${{ secrets.VCS_SSH_KEY }}
-          name: id_rsa
-          known_hosts: ${{ steps.scan.outputs.known_hosts }}
-          if_key_exists: replace
-
-      # Issue an HTTPS -> Git override for VCS repositories
-      - name: Git Config
-        run: |
-          git config --global url."git@github.com:".insteadOf "https://github.com"          
+          pat: ${{ secrets.CICD_TOKEN }}
 
 # TODO: Change this to CD to a valid directory, ensure it will not cause widespread breaks
 #      # Run vet & lint on the code

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -36,4 +36,5 @@ jobs:
         uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
           event: build
+          success: success()
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -52,55 +52,9 @@ jobs:
       - name: Run testing
         run: go test -vet=off -tags internal -v ./...
 
-  notify_build:
-    name: "Notify Build"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [ build ]
-    steps:
-      # https://stackoverflow.com/questions/72221266/sanitize-github-context-in-github-actions
-      - name: "Build Notification"
-        id: slack
-        uses: slackapi/slack-github-action@v1.19.0
+      - name: "Slack Notify"
+        if: success() || failure()
+        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
-          channel-id: 'G3184HDT6' # CICD
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.build.result == 'success' && '#2eb886' || '#a30200' }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*${{github.event.repository.name}}*: Build <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> by ${{github.actor}} ${{ needs.build.result == 'success' && 'successful' || 'failed' }}! ${{ needs.build.result == 'success' && ':ok_hand:' || ':scream::cry:' }}"
-                      }
-                    },
-                    { "type": "divider" },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ${{ toJSON(github.event.head_commit.message) }}
-                      },
-                      "accessory": {
-                        "type": "image",
-                        "image_url": "${{ needs.build.result == 'success' && 'https://popcat.click/twitter-card.jpg' || 'https://www.meme-arsenal.com/memes/aaf82c28cdb84f5ab79dd8eb460c1d11.jpg' }}",
-                        "alt_text": "${{ needs.build.result == 'success' && 'Nice!' || 'Oof.' }}"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ":github: *Repository*: <${{ github.server_url }}/${{ github.repository}}|${{ github.repository }}>\n:git: *Ref*: ${{ github.ref_name}}\n:1234: *Build Number*: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>\n:docker: *Image Tag*: ${{needs.build.outputs.image_tag_build}}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          event: build
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -75,8 +75,8 @@ jobs:
         uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
           event: build
+          success: success()
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
 
   deploy:
     name: "Deploy"
@@ -146,4 +146,5 @@ jobs:
         uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
           event: deploy
+          success: success()
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -70,59 +70,13 @@ jobs:
             ${{ steps.tag.outputs.image_tag_branch }}
           file: ${{ matrix.container == 'php' && 'Dockerfile' || 'Dockerfile.nginx' }}
 
-  notify_build:
-    name: "Notify Build"
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [ build ]
-    continue-on-error: true
-    steps:
-      # https://stackoverflow.com/questions/72221266/sanitize-github-context-in-github-actions
-      - name: "Build Notification"
-        id: slack
-        uses: slackapi/slack-github-action@v1.19.0
+      - name: "Slack Notify"
+        if: success() || failure()
+        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
-          channel-id: 'G3184HDT6' # CICD
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.build.result == 'success' && '#2eb886' || '#a30200' }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*${{github.event.repository.name}}*: Build <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> by ${{github.actor}} ${{ needs.build.result == 'success' && 'successful' || 'failed' }}! ${{ needs.build.result == 'success' && ':ok_hand:' || ':scream::cry:' }}"
-                      }
-                    },
-                    { "type": "divider" },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ${{ toJSON(github.event.head_commit.message) }}
-                      },
-                      "accessory": {
-                        "type": "image",
-                        "image_url": "${{ needs.build.result == 'success' && 'https://popcat.click/twitter-card.jpg' || 'https://www.meme-arsenal.com/memes/aaf82c28cdb84f5ab79dd8eb460c1d11.jpg' }}",
-                        "alt_text": "${{ needs.build.result == 'success' && 'Nice!' || 'Oof.' }}"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ":github: *Repository*: <${{ github.server_url }}/${{ github.repository}}|${{ github.repository }}>\n:git: *Ref*: ${{ github.ref_name}}\n:1234: *Build Number*: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>\n:docker: *Image Tag*: ${{needs.build.outputs.image_tag_build}}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          event: build
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 
   deploy:
     name: "Deploy"
@@ -187,42 +141,9 @@ jobs:
           echo "Updating $CONTAINER in $DEPLOYMENT to $IMAGE in the $NAMESPACE namespace."
           kubectl set image deployment/$DEPLOYMENT  $CONTAINER=$IMAGE --record=true --namespace=${NAMESPACE}
 
-  notify_deploy:
-    name: "Notify Deploy"
-    runs-on: ubuntu-latest
-    if: always() && needs.deploy.result != 'skipped'
-    needs: [ deploy ]
-    steps:
-      - name: "Deployment Notification"
-        id: slack
-        uses: slackapi/slack-github-action@v1.19.0
+      - name: "Slack Notify"
+        if: success() || failure()
+        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
         with:
-          channel-id: 'G3184HDT6' # CICD
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ needs.deploy.result == 'success' && '#2eb886' || '#a30200' }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*${{ needs.deploy.result == 'success' && 'Deployment Success' || 'Deployment Failure' }}: ${{github.event.repository.name}}*"
-                      }
-                    },
-                    { "type": "divider" },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "Deployment <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}> of image ${{needs.build.outputs.image_tag_build}} to *${{github.ref_name}}* ${{ needs.deploy.result == 'success' && 'successful' || 'failed' }}! ${{ needs.deploy.result == 'success' && ':kubernetes::100::peepo_clap:' || ':scream::pepetrashscared:' }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          event: deploy
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: "Slack Notify"
         if: success() || failure()
-        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
+        uses: linc-technologies/.github/.github/actions/slack_notify@master
         with:
           event: build
           success: success()
@@ -143,7 +143,7 @@ jobs:
 
       - name: "Slack Notify"
         if: success() || failure()
-        uses: linc-technologies/.github/.github/actions/slack_notify@feature/composite
+        uses: linc-technologies/.github/.github/actions/slack_notify@master
         with:
           event: deploy
           success: success()


### PR DESCRIPTION
Just tidying up a bit...
Would have added a docker_build action, except for the fact that setting the image tags gets a little interesting per workflow, and Node needs to auth with ACR before everything happens such that it can pull previous assets...

Thought (Out of scope) can we just curl the previous assets if they're still hosted? :rofl: 

Runs:
https://github.com/linc-technologies/auth/runs/7890500720?check_suite_focus=true
https://github.com/linc-technologies/finance/runs/7890500302?check_suite_focus=true