### PR TITLE
feat: change workflows to only run on workflow_call

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -1,8 +1,6 @@
 name: "Ember"
 
 on:
-  pull_request:
-  workflow_dispatch:
   workflow_call:
     # TODO: Deprecate these as we move to helm
     inputs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,6 @@
 name: "Go"
 
 on:
-  workflow_dispatch:
   workflow_call:
 
 env:

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -1,7 +1,6 @@
 name: "Go Module"
 
 on:
-  workflow_dispatch:
   workflow_call:
 
 jobs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,7 +1,6 @@
 name: "PHP"
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       DEPLOYMENT:


### PR DESCRIPTION
I'm pretty sure (As seen in the cli_build and cli_release) workflows, that these options do not need to be specified here, because they do not need to be triggered by this repo.

I believe the additional triggers are a remnant of me learning GA and rushing to set everything up in an afternoon or so.

The child repos have workflow_dispatch (Manual trigger) as well as push / merge hooks, which then call into these central workflows. Ie, the central ones will only ever be invoked

Docs for reference :-) 
https://docs.github.com/en/actions/using-workflows/reusing-workflows#creating-a-reusable-workflow