### PR TITLE
feature/DEVOPS 174 github upgrades

### DIFF
--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -220,6 +220,7 @@ jobs:
   deploy:
     name: "Deploy"
     if: contains(fromJson('["development", "staging", "production"]'), github.ref_name)
+    environment: ${{ github.ref_name }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: "Install Kubectl"
         id: install_kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: 'v1.22.6'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: "Install Kubectl"
         id: install_kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: 'v1.22.6'
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: "Install Kubectl"
         id: install_kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3
         with:
           version: 'v1.22.6'
 


### PR DESCRIPTION
fix: use setup-kubectl v3 in order to resolve deprecated set-output warnings


Finally unblocked:
https://github.com/Azure/setup-kubectl/issues/69#issuecomment-1337906505