### PR TITLE
feature/DEVOPS 197 reuse build label

### DIFF
--- a/.github/actions/build_label/action.yml
+++ b/.github/actions/build_label/action.yml
@@ -1,0 +1,46 @@
+name: "Helm Deploy"
+description: "Install or Upgrade a Helm release in Kubernetes."
+inputs:
+  matrix:
+    description: |
+      If a value is passed in as the matrix parameter, the matrix value will be appended onto the repository name.
+      Eg, linc-ed/print-nginx, linc-ed/print-php
+    required: false
+    default: ""
+outputs:
+  build_number:
+    description: |
+      The build number to use as a tag for container images. This is incremented by 10_000 in order to 
+      avoid collisions with our previous build system (Drone CI).
+    value: ${{ steps.export.outputs.build_number }}
+  docker_build_number:
+    description: "A full Docker image tag based on build number."
+    value: ${{ steps.export.outputs.docker_build_number }}
+  docker_build_branch:
+    description: "A full Docker image tag based on branch."
+    value: ${{ steps.export.outputs.docker_build_number }}
+runs:
+  using: "composite"
+  steps:
+
+    - name: "Export Build Tags"
+      id: export
+      env:
+        BUILD: ${{ github.run_number }}
+        BRANCH: ${{ github.ref_name }}
+        REPO: ${{ github.event.repository.name }}
+        MATRIX: ${{ inputs.matrix }}
+      run: |
+        # Export the build number plus 'safety buffer'
+        BUILD=$(($BUILD+10000))
+        echo "build_number=$BUILD" >> $GITHUB_OUTPUT
+        
+        # If we are given an extra snippet from a matrix build then append it to the registry name.
+        if [ -z "$MATRIX" ] ; then 
+          echo "docker_build_number=linced.azurecr.io/linc-ed/$REPO:$BUILD" >> $GITHUB_OUTPUT
+          echo "docker_build_branch=linced.azurecr.io/linc-ed/$REPO:$BRANCH" >> $GITHUB_OUTPUT
+        else 
+          echo "docker_build_number=linced.azurecr.io/linc-ed/$REPO-$MATRIX:$BUILD" >> $GITHUB_OUTPUT
+          echo "docker_build_branch=linced.azurecr.io/linc-ed/$REPO-$MATRIX:$BRANCH" >> $GITHUB_OUTPUT
+        fi
+      shell: bash

--- a/.github/actions/build_label/action.yml
+++ b/.github/actions/build_label/action.yml
@@ -1,5 +1,5 @@
-name: "Helm Deploy"
-description: "Install or Upgrade a Helm release in Kubernetes."
+name: "Export Build Label"
+description: "Generate standardised build labels for tagging artifacts. Labels are consumable as outputs."
 inputs:
   matrix:
     description: |
@@ -18,7 +18,7 @@ outputs:
     value: ${{ steps.export.outputs.docker_build_number }}
   docker_build_branch:
     description: "A full Docker image tag based on branch."
-    value: ${{ steps.export.outputs.docker_build_number }}
+    value: ${{ steps.export.outputs.docker_build_branch }}
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -13,17 +13,12 @@ on:
         type: string
         required: true
 
-env:
-  CONTAINER_REGISTRY: linced.azurecr.io/linc-ed
-
 jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
     outputs:
-      build_num: ${{ steps.export_build_tag.outputs.build_num }}
-      image_tag_build: ${{ steps.export_build_tag.outputs.image_tag_build }}
-      image_tag_branch: ${{ steps.export_build_tag.outputs.image_tag_branch }}
+      build_number: ${{ steps.export_build_tag.outputs.build_number }}
     steps:
 
       - name: "Checkout"
@@ -175,25 +170,9 @@ jobs:
         if: contains(fromJson('["testing", "development", "staging", "production"]'), github.ref_name)
         uses: docker/setup-buildx-action@v2
 
-      - name: "Export build tag"
+      - name: "Export Build Tag"
         id: export_build_tag
-        if: contains(fromJson('["testing", "development", "staging", "production"]'), github.ref_name)
-        env:
-          BUILD: ${{ github.run_number }}
-        run: |
-          echo "build_num=$(($BUILD+10000))" >> $GITHUB_OUTPUT
-          echo "image_tag_build=${{env.CONTAINER_REGISTRY}}/${{ github.event.repository.name }}:$(($BUILD+10000))" >> $GITHUB_OUTPUT
-          echo "image_tag_branch=${{env.CONTAINER_REGISTRY}}/${{ github.event.repository.name }}:${{github.ref_name}}" >> $GITHUB_OUTPUT
-
-#      - name: "Build and export to Docker"
-#        id: build_and_export_to_docker
-#        uses: docker/build-push-action@v3
-#        if: ${{ !contains(fromJson('["testing", "development", "staging", "production"]'), github.ref_name) }}
-#        with:
-#          context: .
-#          push: true
-#          tags: ${{ steps.export_build_tag.outputs.image_tag_build }}
-#          file: Dockerfile.drone
+        uses: linc-technologies/.github/.github/actions/build_label@master
 
       - name: "Build and export to Docker (Environmental Tags)"
         id: build_and_export_to_docker_environmental_tags
@@ -277,30 +256,13 @@ jobs:
       - name: "Helm Deploy"
         id: helm_deploy
         uses: linc-technologies/.github/.github/actions/deploy_helm@master
-        # TODO: Remove once fully cutover.
-        if: ${{ github.ref_name == 'development' || github.ref_name == 'staging' }}
         with:
           chart: "app"
           release: ${{ steps.release_name.outputs.release_name }}
           namespace: ${{ github.ref_name }}
-          tag: ${{ needs.build.outputs.build_num }}
+          tag: ${{ needs.build.outputs.build_number }}
           oci_user: ${{ secrets.AZURE_ACR_LINCED_USERNAME }}
           oci_pass: ${{ secrets.AZURE_ACR_LINCED_PASSWORD }}
-
-      # Deploy to other environments if we did not deploy with Helm (Staging, Production) via k8s Deployment patch
-      # TODO: Remove once fully cutover
-      # Deploy specific container revision based on workflow inputs
-      - name: "Kubernetes Deploy"
-        id: kubernetes_deploy
-        if: steps.helm_deploy.conclusion == 'skipped'
-        env:
-          CONTAINER: ${{ inputs.CONTAINER }}
-          DEPLOYMENT: ${{ inputs.DEPLOYMENT }}
-          NAMESPACE: ${{ github.ref_name }}
-          IMAGE: ${{ needs.build.outputs.image_tag_build }}
-        run: |
-          echo "Updating $CONTAINER in $DEPLOYMENT to $IMAGE in the $NAMESPACE namespace."
-          kubectl set image deployment/$DEPLOYMENT  $CONTAINER=$IMAGE --record=true --namespace=${NAMESPACE}
 
       - name: "Slack Notify"
         if: success() || failure()

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -239,30 +239,24 @@ jobs:
           version: 'v1.22.6'
 
       # If we're deploying from a non-production branch, configure Kubectl with Dev cluster secrets
-      - name: "Kubernetes Auth (Dev AU East)"
-        id: kubernetes_auth_dev_au_east
-        if: ${{ github.ref  != 'refs/heads/production' }}
-        run: |
-          kubectl config set-credentials default --token=${{ secrets.DEVELOPMENT_AU_EAST_AKS_TOKEN }}
-          # If cert provided...
-          # kubectl config set-cluster default --server=${{ secrets.DEVELOPMENT_AU_EAST_AKS_SERVER }} --certificate-authority=ca.crt
-          # If cert not provided
-          kubectl config set-cluster default --server=${{ secrets.DEVELOPMENT_AU_EAST_AKS_SERVER }} --insecure-skip-tls-verify=true
-          kubectl config set-context default --cluster=default --user=default
-          kubectl config use-context default
+      - name: "Configure Kubectl (development-au-east)"
+        id: configure_kubectl_development_au_east
+        if: ${{ github.ref != 'refs/heads/production' }}
+        uses: linc-technologies/.github/.github/actions/k8s_auth@master
+        with:
+          server: ${{ secrets.DEVELOPMENT_AU_EAST_AKS_SERVER }}
+          token: ${{ secrets.DEVELOPMENT_AU_EAST_AKS_TOKEN }}
+          cert: ${{ secrets.DEVELOPMENT_AU_EAST_AKS_CERT }}
 
       # If we're deploying from a production branch, configure Kubectl with Prod cluster secrets
-      - name: "Kubernetes Auth (Prod AU East)"
-        id: kubernetes_auth_prod_au_east
+      - name: "Configure Kubectl (production-au-east)"
+        id: configure_kubectl_production_au_east
         if: ${{ github.ref == 'refs/heads/production' }}
-        run: |
-          kubectl config set-credentials default --token=${{ secrets.PRODUCTION_AU_EAST_AKS_TOKEN }}
-          # If cert provided...
-          # kubectl config set-cluster default --server=${{ secrets.PRODUCTION_AU_EAST_AKS_SERVER }} --certificate-authority=ca.crt
-          # If cert not provided
-          kubectl config set-cluster default --server=${{ secrets.PRODUCTION_AU_EAST_AKS_SERVER }} --insecure-skip-tls-verify=true
-          kubectl config set-context default --cluster=default --user=default
-          kubectl config use-context default
+        uses: linc-technologies/.github/.github/actions/k8s_auth@master
+        with:
+          server: ${{ secrets.PRODUCTION_AU_EAST_AKS_SERVER }}
+          token: ${{ secrets.PRODUCTION_AU_EAST_AKS_TOKEN }}
+          cert: ${{ secrets.PRODUCTION_AU_EAST_AKS_CERT }}
 
       - name: "Kubectl Version"
         id: kubectl_version

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -182,8 +182,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.export_build_tag.outputs.image_tag_build }}
-            ${{ steps.export_build_tag.outputs.image_tag_branch }}
+            ${{ steps.export_build_tag.outputs.docker_build_number }}
+            ${{ steps.export_build_tag.outputs.docker_build_branch }}
           file: Dockerfile.drone
 
       - name: "Slack Notify"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           context: .
           push: false
-          tags: ${{ steps.export_build_tag.outputs.image_tag_build }}
+          tags: ${{ steps.export_build_tag.outputs.docker_build_number }}
           file: Dockerfile.drone
 
       - name: "Build and export to Docker (Environment Based)"
@@ -92,8 +92,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.export_build_tag.outputs.image_tag_build }}
-            ${{ steps.export_build_tag.outputs.image_tag_branch }}
+            ${{ steps.export_build_tag.outputs.docker_build_number }}
+            ${{ steps.export_build_tag.outputs.docker_build_branch }}
           file: Dockerfile.drone
 
       - name: "Slack Notify"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -139,7 +139,7 @@ jobs:
       # If we're deploying from a non-production branch, configure Kubectl with Dev cluster secrets
       - name: "Configure Kubectl (development-au-east)"
         id: configure_kubectl_development_au_east
-        if: ${{ github.ref  != 'refs/heads/production' }}
+        if: ${{ github.ref != 'refs/heads/production' }}
         uses: linc-technologies/.github/.github/actions/k8s_auth@master
         with:
           server: ${{ secrets.DEVELOPMENT_AU_EAST_AKS_SERVER }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,17 +3,12 @@ name: "Go"
 on:
   workflow_call:
 
-env:
-  CONTAINER_REGISTRY: linced.azurecr.io/linc-ed
-
 jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
     outputs:
-      build_num: ${{ steps.export_build_tag.outputs.build_num }}
-      image_tag_build: ${{ steps.export_build_tag.outputs.image_tag_build }}
-      image_tag_branch: ${{ steps.export_build_tag.outputs.image_tag_branch }}
+      build_number: ${{ steps.export_build_tag.outputs.build_number }}
     steps:
 
       - name: "Checkout"
@@ -75,14 +70,9 @@ jobs:
           username: ${{ secrets.AZURE_ACR_LINCED_USERNAME }}
           password: ${{ secrets.AZURE_ACR_LINCED_PASSWORD }}
 
-      - name: "Export build tag"
+      - name: "Export Build Tag"
         id: export_build_tag
-        env:
-          BUILD: ${{ github.run_number }}
-        run: |
-          echo "build_num=$(($BUILD+10000))" >> $GITHUB_OUTPUT
-          echo "image_tag_build=${{env.CONTAINER_REGISTRY}}/${{ github.event.repository.name }}:$(($BUILD+10000))" >> $GITHUB_OUTPUT
-          echo "image_tag_branch=${{env.CONTAINER_REGISTRY}}/${{ github.event.repository.name }}:${{github.ref_name}}" >> $GITHUB_OUTPUT
+        uses: linc-technologies/.github/.github/actions/build_label@master
 
       - name: "Build and export to Docker"
         id: build_and_export_to_docker
@@ -156,8 +146,7 @@ jobs:
           token: ${{ secrets.PRODUCTION_AU_EAST_AKS_TOKEN }}
           cert: ${{ secrets.PRODUCTION_AU_EAST_AKS_CERT }}
 
-      # Showcase the client and server Kubectl versions
-      - name: "Kubectl Version (Client & Server)"
+      - name: "Kubectl Version"
         id: kubectl_version
         run: kubectl version
 
@@ -168,7 +157,7 @@ jobs:
           chart: "service"
           release: ${{ github.event.repository.name }}
           namespace: ${{ github.ref_name }}
-          tag: ${{ needs.build.outputs.build_num }}
+          tag: ${{ needs.build.outputs.build_number }}
           oci_user: ${{ secrets.AZURE_ACR_LINCED_USERNAME }}
           oci_pass: ${{ secrets.AZURE_ACR_LINCED_PASSWORD }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,13 +3,12 @@ name: "PHP"
 on:
   workflow_call:
 
-env:
-  CONTAINER_REGISTRY: linced.azurecr.io/linc-ed
-
 jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
+    outputs:
+      build_number: ${{ steps.export_build_tag.outputs.build_number }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,24 +31,9 @@ jobs:
         id: set_up_docker_buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: "Export build tag"
+      - name: "Export Build Tag"
         id: export_build_tag
-        env:
-          BUILD: ${{ github.run_number }}
-        run: |
-          echo "build_num=$(($BUILD+10000))" >> $GITHUB_OUTPUT
-          echo "image_tag_build=${{env.CONTAINER_REGISTRY}}/${{ github.event.repository.name }}-${{matrix.container}}:$(($BUILD+10000))" >> $GITHUB_OUTPUT
-          echo "image_tag_branch=${{env.CONTAINER_REGISTRY}}/${{ github.event.repository.name }}-${{matrix.container}}:${{github.ref_name}}" >> $GITHUB_OUTPUT
-
-      - name: "Build and export to Docker"
-        id: build_and_export_to_docker
-        uses: docker/build-push-action@v3
-        if: ${{ !contains(fromJson('["development", "staging", "production"]'), github.ref_name) }}
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.export_build_tag.outputs.image_tag_build }}
-          file: ${{ matrix.container == 'php' && 'Dockerfile' || 'Dockerfile.nginx' }}
+        uses: linc-technologies/.github/.github/actions/build_label@master
 
       - name: "Build and export to Docker (Environment Based)"
         id: build_and_export_to_docker_environment_based
@@ -59,8 +43,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.export_build_tag.outputs.image_tag_build }}
-            ${{ steps.export_build_tag.outputs.image_tag_branch }}
+            ${{ steps.export_build_tag.outputs.docker_build_number }}
+            ${{ steps.export_build_tag.outputs.docker_build_branch }}
           file: ${{ matrix.container == 'php' && 'Dockerfile' || 'Dockerfile.nginx' }}
 
       - name: "Slack Notify"
@@ -117,13 +101,6 @@ jobs:
         id: kubectl_version
         run: kubectl version
 
-      - name: "Export build tag"
-        id: export_build_tag
-        env:
-          BUILD: ${{ github.run_number }}
-        run: |
-          echo "build_num=$(($BUILD+10000))" >> $GITHUB_OUTPUT
-
       - name: "Helm Deploy"
         id: helm_deploy
         uses: linc-technologies/.github/.github/actions/deploy_helm@master
@@ -131,7 +108,7 @@ jobs:
           chart: "php"
           release: ${{ github.event.repository.name }}
           namespace: ${{ github.ref_name }}
-          tag: ${{ steps.export_build_tag.outputs.build_num }}
+          tag: ${{ needs.build.outputs.build_number }}
           oci_user: ${{ secrets.AZURE_ACR_LINCED_USERNAME }}
           oci_pass: ${{ secrets.AZURE_ACR_LINCED_PASSWORD }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -94,9 +94,9 @@ jobs:
           version: 'v1.22.6'
 
       # If we're deploying from a non-production branch, configure Kubectl with Dev cluster secrets
-      - name: "Kubernetes Auth (Dev AU East)"
-        id: kubernetes_auth_dev_au_east
-        if: ${{ github.ref  != 'refs/heads/production' }}
+      - name: "Configure Kubectl (development-au-east)"
+        id: configure_kubectl_development_au_east
+        if: ${{ github.ref != 'refs/heads/production' }}
         uses: linc-technologies/.github/.github/actions/k8s_auth@master
         with:
           server: ${{ secrets.DEVELOPMENT_AU_EAST_AKS_SERVER }}
@@ -104,8 +104,8 @@ jobs:
           cert: ${{ secrets.DEVELOPMENT_AU_EAST_AKS_CERT }}
 
       # If we're deploying from a production branch, configure Kubectl with Prod cluster secrets
-      - name: "Kubernetes Auth (Prod AU East)"
-        id: kubernetes_auth_prod_au_east
+      - name: "Configure Kubectl (production-au-east)"
+        id: configure_kubectl_production_au_east
         if: ${{ github.ref == 'refs/heads/production' }}
         uses: linc-technologies/.github/.github/actions/k8s_auth@master
         with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,6 +34,8 @@ jobs:
       - name: "Export Build Tag"
         id: export_build_tag
         uses: linc-technologies/.github/.github/actions/build_label@master
+        with:
+          matrix: ${{ matrix.container }}
 
       - name: "Build and export to Docker (Environment Based)"
         id: build_and_export_to_docker_environment_based


### PR DESCRIPTION
- chore: make kubernetes auth steps consistent across workflows
- feat: create new action to export build labels and cut all build workflows across to use it

Now that we are using helm for everything, the chart is capable of figuring out the image name based, and it only needs the image tag in order to update the deployment.

This benefits us as the PHP deployment no longer needs to know the full `<registry>/print-<matrix>` value for each image. This was previously a problem, as exporting outputs in a matrix scenario was slightly difficult.
Now, even if an output  is overwritten, it will be with the same minimal `build_number` value, meaning we do not need to have it explicitly re-caclulated in the deployment stage :+1: 