### PR TITLE
feature/DEVOPS 188 helm monorepo deploy

### DIFF
--- a/.github/actions/deploy_helm/action.yml
+++ b/.github/actions/deploy_helm/action.yml
@@ -30,11 +30,10 @@ runs:
 
     - name: "Helm Deploy"
       run: |
-        cd ./deployments/
         helm registry login linced.azurecr.io --username ${{ inputs.oci_user }} --password ${{ inputs.oci_pass }}
         helm upgrade -i ${{ inputs.release }} oci://linced.azurecr.io/helm/${{ inputs.chart }}-chart \
           --namespace ${{ inputs.namespace }} \
-          -f ./values.${{ inputs.namespace }}.yaml \
+          -f ${{ inputs.chart }}-chart/${{ inputs.release }}/values.${{ inputs.namespace }}.yaml \
           --set image.tag=${{ inputs.tag }} \
           --wait --timeout 2m
       shell: bash

--- a/.github/actions/deploy_helm/action.yml
+++ b/.github/actions/deploy_helm/action.yml
@@ -33,7 +33,7 @@ runs:
         helm registry login linced.azurecr.io --username ${{ inputs.oci_user }} --password ${{ inputs.oci_pass }}
         helm upgrade -i ${{ inputs.release }} oci://linced.azurecr.io/helm/${{ inputs.chart }}-chart \
           --namespace ${{ inputs.namespace }} \
-          -f ${{ inputs.chart }}-chart/${{ inputs.release }}/values.${{ inputs.namespace }}.yaml \
+          -f values/${{ inputs.chart }}-chart/${{ inputs.release }}/values.${{ inputs.namespace }}.yaml \
           --set image.tag=${{ inputs.tag }} \
           --wait --timeout 2m
       shell: bash

--- a/.github/workflows/ember.yml
+++ b/.github/workflows/ember.yml
@@ -219,15 +219,18 @@ jobs:
 
   deploy:
     name: "Deploy"
-    if: contains(fromJson('["development", "staging", "production"]'), github.ref_name)
+    if: contains(fromJson('["testing", "development", "staging", "production"]'), github.ref_name)
     environment: ${{ github.ref_name }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      # In order to retrieve deployment config
+
       - name: "Checkout"
         id: checkout
         uses: actions/checkout@v3
+        with:
+          repository: linc-technologies/helm
+          token: ${{ secrets.CICD_TOKEN }}
 
       - name: "Install Kubectl"
         id: install_kubectl

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -117,13 +117,12 @@ jobs:
 
   deploy:
     name: "Deploy"
-    if: contains(fromJson('["development", "staging", "production"]'), github.ref_name)
+    if: contains(fromJson('["testing", "development", "staging", "production"]'), github.ref_name)
     environment: ${{ github.ref_name }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:
 
-      # In order to retrieve deployment config
       - name: "Checkout"
         id: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -127,6 +127,9 @@ jobs:
       - name: "Checkout"
         id: checkout
         uses: actions/checkout@v3
+        with:
+          repository: linc-technologies/helm
+          token: ${{ secrets.CICD_TOKEN }}
 
       - name: "Install Kubectl"
         id: install_kubectl
@@ -164,6 +167,7 @@ jobs:
         uses: linc-technologies/.github/.github/actions/deploy_helm@master
         # TODO: Adjust this filter for Staging, and Production when ready to cutover.
         if: ${{ github.ref_name == 'development' }}
+        working_directory: values/
         with:
           chart: "service"
           release: ${{ github.event.repository.name }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -166,7 +166,6 @@ jobs:
         uses: linc-technologies/.github/.github/actions/deploy_helm@master
         # TODO: Adjust this filter for Staging, and Production when ready to cutover.
         if: ${{ github.ref_name == 'development' }}
-        working_directory: values/
         with:
           chart: "service"
           release: ${{ github.event.repository.name }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -74,15 +74,18 @@ jobs:
 
   deploy:
     name: "Deploy"
-    if: contains(fromJson('["development", "staging", "production"]'), github.ref_name)
+    if: contains(fromJson('["testing", "development", "staging", "production"]'), github.ref_name)
     environment: ${{ github.ref_name }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:
 
-      # In order to retrieve deployment config
       - name: "Checkout"
-        uses: actions/checkout@v2
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          repository: linc-technologies/helm
+          token: ${{ secrets.CICD_TOKEN }}
 
       - name: "Install Kubectl"
         id: install_kubectl


### PR DESCRIPTION
Changes to using a central repository for Helm deployment config. Has the nice benefit of a trunk based branching strategy.
Centralisation is more powerful to us than the individual flexibility that came with a per repo config unfortunately.

- feat(helm): when deploying checkout the helm repository and use values from there
- chore: allow deployments on branches named "testing"
- chore: remove working directory directive from helm deploy call and shift it into action
