### PR TITLE
Revert "feat(go): allow for inclusion of symbols in development golang builds"

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,20 +38,8 @@ jobs:
         id: format
         run: if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then exit 1; fi
 
-      # Publish symbols for development build branches in order to
-      - name: "Build (DWARF)"
-        id: build_debug
-        if: ${{ github.ref_name == 'development' }}
-        env:
-          GOPRIVATE: github.com/linc-technologies
-          CGO_ENABLED: 0
-        run: |
-          cd ./cmd/${{ github.event.repository.name }}/
-          go build -tags internal -v
-
       - name: "Build"
         id: build
-        if: ${{ github.ref_name != 'development' }}
         env:
           GOPRIVATE: github.com/linc-technologies
           CGO_ENABLED: 0


### PR DESCRIPTION
Reverts linc-technologies/.github#66

Pixie would require a LOT of RAM to store data in memory, we will likely pursue a different approach for APM.
As Pixie is uninstalled, we can revert this (Was implemented to allow gRPC auto tracing) 