### PR TITLE
fix(.github/actions/slack_notify): attempt to fix sending a null payload.

### DIFF
--- a/.github/actions/slack_notify/action.yml
+++ b/.github/actions/slack_notify/action.yml
@@ -39,7 +39,7 @@ runs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": ${{ toJSON(github.event.head_commit.message) || 'No commit message' }}
+                      "text": ${{ toJSON(github.event.head_commit.message || env.EMPTY_COMMIT_MSG) }}
                     },
                     "accessory": {
                       "type": "image",
@@ -61,6 +61,7 @@ runs:
       env:
         SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        EMPTY_COMMIT_MSG: _No commit message_
 
     - name: "Deployment Notification"
       if: inputs.event == 'deploy'


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18T2A1LWqRaa6MKsAnBL9FVDprsutqesw%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=LG74xwp)

(attempt to) Feed in a default message if the commit message is empty or null to `toJSON`