### PR TITLE
feat: golangci-lint tweaks

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,7 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest
           # https://golangci-lint.run/usage/configuration/#command-line-options
-          args: --issues-exit-code=0 --build-tags=internal
+          args: --issues-exit-code=0 --build-tags=internal --go=1.19
 
       - name: "Build"
         id: build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,16 +35,15 @@ jobs:
         run: if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then exit 1; fi
 
       - name: "Lint"
-        id: golangci
+        id: lint
         uses: golangci/golangci-lint-action@v3
-        continue-on-error: true
         env:
           GOPRIVATE: github.com/linc-technologies
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.51
+          version: latest
           # https://golangci-lint.run/usage/configuration/#command-line-options
-          args: --issues-exit-code=0
+          args: --issues-exit-code=0 --build-tags=internal
 
       - name: "Build"
         id: build

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -36,7 +36,7 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest
           # https://golangci-lint.run/usage/configuration/#command-line-options
-          args: --issues-exit-code=0 --build-tags=internal
+          args: --issues-exit-code=0 --build-tags=internal --go=${{ matrix.go }}
 
       - name: "Git HTTPS"
         id: git_https

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -28,12 +28,15 @@ jobs:
         run: if [ "$(gofmt -l . | wc -l)" -gt 0 ]; then exit 1; fi
 
       - name: "Lint"
-        # TODO: Expand to the other modules once proven / rectified
-        if: github.event.repository.name == 'go-wonde'
         id: lint
         uses: golangci/golangci-lint-action@v3
+        env:
+          GOPRIVATE: github.com/linc-technologies
         with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest
+          # https://golangci-lint.run/usage/configuration/#command-line-options
+          args: --issues-exit-code=0 --build-tags=internal
 
       - name: "Git HTTPS"
         id: git_https


### PR DESCRIPTION
 - enable golangci-lint across all modules
 - add `internal` build tag to lint
 - swap to the latest version of golangci-lint across the board
