### PR TITLE
chore(workflows/go): increases lint timeout.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,7 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest
           # https://golangci-lint.run/usage/configuration/#command-line-options
-          args: --issues-exit-code=0 --build-tags=internal --go=1.19
+          args: --issues-exit-code=0 --build-tags=internal --go=1.19 --timeout=2m --verbose
 
       - name: "Build"
         id: build


### PR DESCRIPTION
Also enables verbose output to debug golangci-lint related issues.