### PR TITLE
chore(workflows/go_module): increases lint timeout.

### DIFF
--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -36,7 +36,7 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest
           # https://golangci-lint.run/usage/configuration/#command-line-options
-          args: --issues-exit-code=0 --build-tags=internal --go=${{ matrix.go }}
+          args: --issues-exit-code=0 --build-tags=internal --go=${{ matrix.go }} --timeout=2m --verbose
 
       - name: "Git HTTPS"
         id: git_https


### PR DESCRIPTION
Also enables verbose output to debug golangci-lint related issues.