### PR TITLE
:zap: pin golangci-lint to v1.52

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,7 +41,7 @@ jobs:
           GOPRIVATE: github.com/linc-technologies
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: latest
+          version: v1.52
           # https://golangci-lint.run/usage/configuration/#command-line-options
           args: --issues-exit-code=0 --build-tags=internal --go=1.19 --timeout=2m --verbose
 

--- a/.github/workflows/go_module.yml
+++ b/.github/workflows/go_module.yml
@@ -34,7 +34,7 @@ jobs:
           GOPRIVATE: github.com/linc-technologies
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: latest
+          version: v1.52
           # https://golangci-lint.run/usage/configuration/#command-line-options
           args: --issues-exit-code=0 --build-tags=internal --go=${{ matrix.go }} --timeout=2m --verbose
 


### PR DESCRIPTION
v1.53 upgraded `depguard` to a version which fails due to an incorrect GOROOT.  Pinning to v1.52 should allow builds to work again until it's fixed. See https://github.com/golangci/golangci-lint/issues/3862